### PR TITLE
Fixed tdesktop archive name.

### DIFF
--- a/telegram-desktop.spec
+++ b/telegram-desktop.spec
@@ -9,7 +9,7 @@ Release: 2%{?dist}
 Group: Applications/Internet
 License: GPLv3
 URL: https://github.com/telegramdesktop
-Source0: %{url}/%{_APPNAME}/archive/v%{version}.tar.gz
+Source0: %{url}/%{_APPNAME}/archive/v%{version}/%{_APPNAME}-%{version}.tar.gz
 Source1: https://download.qt.io/official_releases/qt/5.6/5.6.0/submodules/qtbase-opensource-src-5.6.0.tar.xz
 Source2: https://download.qt.io/official_releases/qt/5.6/5.6.0/submodules/qtimageformats-opensource-src-5.6.0.tar.xz
 Source3: https://chromium.googlesource.com/external/gyp/+archive/master.tar.gz#/gyp.tar.gz


### PR DESCRIPTION
When building multiple spec files, downloading multiple archives into `%{_sourcedir}`, it is confusing when an archive does not contain the software's name.